### PR TITLE
fix logo margin

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -43,7 +43,7 @@ under the License.
     </a>
     <div class="tocify-wrapper">
       <%= image_tag "logo.png" %>
-      <% if language_tabs %>
+      <% if language_tabs.any? %>
         <div class="lang-selector">
           <% language_tabs.each do |lang| %>
             <% if lang.is_a? Hash %>


### PR DESCRIPTION
I followed the instructions(https://github.com/lord/slate/wiki/Changing-the-Logo) to customize my logo margin, However, $logo-margin doesn't work. I finally figure out that the layout.erb has a bug when checking language_tabs:(https://github.com/lord/slate/blob/master/source/layouts/layout.erb#L46). Because the topcify css class is defined as "img+.tocify"(https://github.com/lord/slate/blob/master/source/stylesheets/screen.css.scss#L113), so the margin value will always be ignored because of the lang-selector div.

By the way, thank you for your amazing project! It helps me save a lot of time!

