### PR TITLE
Latest middleman - fixing startup arguments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,6 @@ Vagrant.configure(2) do |config|
       echo "Starting up middleman at http://localhost:4567"
       echo "If it does not come up, check the ~/middleman.log file for any error messages"
       cd /vagrant
-      bundle exec middleman server --watcher-force-polling --watcher_latency=1 &> ~/middleman.log &
+      bundle exec middleman server --force-polling --latency=1 &> ~/middleman.log &
     SHELL
 end


### PR DESCRIPTION
Sorry, I didn't read that line careful enough: "please submit to our dev branch"
Submitting to the `dev`.

So, the current Vagrantfile doesn't start the middleman correctly. Fixed the CLI argumentsas per https://github.com/middleman/middleman/issues/1866#issuecomment-221125503
Tested. It works.