### PR TITLE
Update redcarpet gem to 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gem 'middleman-syntax', '~> 3.0.0'
 gem 'middleman-autoprefixer', '~> 2.7.0'
 gem "middleman-sprockets", "~> 4.0.0"
 gem 'rouge', '~> 2.0.5'
-gem 'redcarpet', '~> 3.3.2'
+gem 'redcarpet', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redcarpet (3.3.4)
+    redcarpet (3.4.0)
     rouge (2.0.5)
     sass (3.4.22)
     servolux (0.12.0)
@@ -115,8 +115,8 @@ DEPENDENCIES
   middleman-autoprefixer (~> 2.7.0)
   middleman-sprockets (~> 4.0.0)
   middleman-syntax (~> 3.0.0)
-  redcarpet (~> 3.3.2)
+  redcarpet (~> 3.4.0)
   rouge (~> 2.0.5)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
Update redcarpet gem to 3.4.0 which will solve the unicode error with h1/h2.

See https://github.com/vmg/redcarpet/issues/538

