### PR TITLE
Fixing an issue when no language is specified

### DIFF
--- a/lib/multilang.rb
+++ b/lib/multilang.rb
@@ -1,7 +1,7 @@
 module Multilang
   def block_code(code, full_lang_name)
     parts = full_lang_name.split('--')
-    rouge_lang_name = parts[0] || ""
+    rouge_lang_name = (parts) ? parts[0] : "" # just parts[0] here causes null ref exception when no language specified
     super(code, rouge_lang_name).sub("highlight #{rouge_lang_name}") do |match|
       match + " tab-" + full_lang_name
     end


### PR DESCRIPTION
parts[0] can lead to a nil class exception. Using the ternary gives the same functionality without causing things to fail. I verified this while porting documentation that had code blocks that did not specify a syntax highlighting language

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", you are submitting your change to ALL USERS OF SLATE, not just your company. This is probably not what you want. Click "base fork" to change it to the right place.

If you're actually trying to submit a change to upstream Slate, please submit to our dev branch, PRs sent to the master branch are generally rejected.
