### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:2-alpine
+MAINTAINER Robert Lord <hello@lord.io>
+WORKDIR /app
+EXPOSE 4567
+
+### install system packages
+RUN apk update && apk add --no-cache \
+    build-base \
+    nodejs \
+    libxml2 \
+    libxml2-dev
+
+### install required gems
+COPY Gemfile* /app/
+RUN bundle install
+
+### copy in entire app last
+COPY . /app/
+
+### execute development server (better way for official docker?)
+CMD [ \   
+    "bundle", \
+    "exec", \
+    "middleman", \
+    "server", \
+    "--watcher-force-polling", \
+    "--watcher-latency=1" \
+]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">Slate helps you create beautiful, intelligent, responsive API documentation.</p>
 
-<p align="center"><img src="https://dl.dropboxusercontent.com/u/95847291/github%20images/slate/slate_screenshot_new.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/lord/img/master/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
 
 <p align="center"><em>The example above was created with Slate. Check it out at <a href="https://lord.github.io/slate">lord.github.io/slate</a>.</em></p>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ bundle exec middleman server
 
 # OR run this to run with vagrant
 vagrant up
+
+# OR run this for docker-compose
+docker-compose up
 ```
 
 You can now see the docs at http://localhost:4567. Whoa! That was fast!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+    app:
+        image: lord/slate:${TAG:-development}
+        build: .
+        hostname: slate
+        ports:
+            - 4567:4567
+        volumes:
+            - .:/app


### PR DESCRIPTION
Adds Docker / Docker Compose support as a drop in replacement for installing software locally, or running Vagrant virtual machines in order to develop on Slate (upstream or down).  Usage is simple:

```bash
### run slate (will build on the first time)

$ docker-compose up


### build (again) if docker config changes

$ docker-compose build
```


I've had a hard time dealing with Middleman, as it is incredibly slow to load.  I don't know if that is anything knew, as Google suggests there are plenty of people who have the same experience.  Not knowing Middleman, I'll have to assume this is normal behavior, but will be happy to adjust the PR if there are any suggestions.
