### PR TITLE
Issue #706 Fixed: Add JavaScript Runtime to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Companies Using Slate
 * [NASA](https://api.nasa.gov)
 * [IBM](https://docs.cloudant.com/api.html)
 * [Sony](http://developers.cimediacloud.com)
-* [Mozilla](http://localforage.github.io/localForage/)
 * [Best Buy](https://bestbuyapis.github.io/api-documentation/)
 * [Travis-CI](https://docs.travis-ci.com/api/)
 * [Greenhouse](https://developers.greenhouse.io/harvest.html)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">Slate helps you create beautiful, intelligent, responsive API documentation.</p>
 
-<p align="center"><img src="https://dl.dropboxusercontent.com/u/95847291/github%20images/slate/slate_screenshot_new.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/lord/img/master/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
 
 <p align="center"><em>The example above was created with Slate. Check it out at <a href="https://lord.github.io/slate">lord.github.io/slate</a>.</em></p>
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Now that Slate is all set up on your machine, you'll probably want to learn more
 
 If you'd prefer to use Docker, instructions are available [in the wiki](https://github.com/lord/slate/wiki/Docker).
 
+### Note on JavaScript Runtime
+
+For those who don't have JavaScript runtime or are experiencing JavaScript runtime issues with ExecJS, it is recommended to add the [rubyracer gem](https://github.com/cowboyd/therubyracer) to your gemfile and run `bundle` again.
+
 Companies Using Slate
 ---------------------------------
 


### PR DESCRIPTION
This PR adds a short note on letting users know that, if they don't have JavaScript runtime or have JavaScript runtime issues, they should add the rubyracer gem to there Gemfile. 

This closes #706.