### PR TITLE
Add ability to run slate using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.3.4
+
+RUN apt-get update -qq
+
+RUN apt-get install -y \
+  build-essential \
+  libxml2-dev \
+  libxslt1-dev \
+  nodejs
+
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile* /usr/src/app/
+RUN gem install bundler --no-ri --no-rdoc
+RUN bundle install
+
+COPY . /usr/src/app
+
+EXPOSE 4567
+
+# CMD bundle exec middleman server -p 4567 --watcher-force-polling --watcher-latency=1 --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY . /usr/src/app
 
 EXPOSE 4567
 
-# CMD bundle exec middleman server -p 4567 --watcher-force-polling --watcher-latency=1 --verbose
+CMD bundle exec middleman server -p 4567 --watcher-force-polling --watcher-latency=1 --verbose

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You're going to need:
 1. Fork this repository on Github.
 2. Clone *your forked repository* (not our original one) to your hard drive with `git clone https://github.com/YOURUSERNAME/slate.git`
 3. `cd slate`
-4. Initialize and start Slate. You can either do this locally, or with Vagrant:
+4. Initialize and start Slate. You can either do this locally, with Vagrant, or with Docker:
 
 ```shell
 # either run this to run locally
@@ -54,6 +54,10 @@ bundle exec middleman server
 
 # OR run this to run with vagrant
 vagrant up
+
+# OR run this to run with Docker
+docker build -t slate .
+docker run -it --rm -p 4567:4567 slate
 ```
 
 You can now see the docs at http://localhost:4567. Whoa! That was fast!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '2'
-services:
-  web:
-    build: .
-    command: bundle exec middleman server -p 4567 --watcher-force-polling --watcher-latency=1 --verbose
-    ports:
-      - "4567:4567"
-    volumes:
-      - .:/usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: bundle exec middleman server -p 4567 --watcher-force-polling --watcher-latency=1 --verbose
+    ports:
+      - "4567:4567"
+    volumes:
+      - .:/usr/src/app


### PR DESCRIPTION
I have an issue that I cannot run Vagrant boxes if I have Docker for Windows installed, so I have added a `Dockerfile` to this project with instructions in the readme on how to spin up a new container.