### PR TITLE
Prevent jumping text when adding `search-highlight`

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -497,7 +497,7 @@ html, body {
 
   .search-highlight {
     padding: 2px;
-    margin: -2px;
+    margin: -3px;
     border-radius: 4px;
     border: 1px solid #F7E633;
     background: linear-gradient(to top left, #F7E633 0%, #F1D32F 100%);


### PR DESCRIPTION
- Add border width to negative margin to prevent jumping text

Before:
![before](https://user-images.githubusercontent.com/1174951/28662894-fd58dfda-72bb-11e7-908b-ddcd45177dd8.gif)

After:
![after](https://user-images.githubusercontent.com/1174951/28662897-02084cf0-72bc-11e7-9607-dac7cf4aa272.gif)
