### PR TITLE
nowrap fix inside content table

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -405,6 +405,9 @@ html, body {
       text-align: left;
       vertical-align: top;
       line-height: 1.6;
+      code {
+        white-space: nowrap;
+      }
     }
 
     th {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6507454/29126627-2e49e0cc-7d1f-11e7-9025-f8cd59313949.png)

Without the nowrap css fix, it was breaking the `code` tag in two lines, which was not pretty.