### PR TITLE
add support for optional 'home_link' field

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,6 +1,8 @@
 ---
 title: API Reference
 
+home_link: https://github.com/lord/slate
+
 language_tabs: # must be one of https://git.io/vQNgJ
   - shell
   - ruby

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -51,7 +51,16 @@ under the License.
       </span>
     </a>
     <div class="toc-wrapper">
+      <% if current_page.data.home_link %>
+        <a href="<%= current_page.data.home_link %>">
+      <% end %>
+
       <%= image_tag "logo.png", class: 'logo' %>
+
+      <% if current_page.data.home_link %>
+        </a>
+      <% end %>
+
       <% if language_tabs.any? %>
         <div class="lang-selector">
           <% language_tabs.each do |lang| %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -71,7 +71,7 @@ html, body {
   }
 
   // This is the logo at the top of the ToC
-  &>img {
+  &>img, &>a img {
     display: block;
     max-width: 100%;
   }


### PR DESCRIPTION
Sometimes the docs aren't the main page and you want to link back to a "home page" this adds support for a field in the index markdown to add a home link that will turn the logo into an anchor tag.