### PR TITLE
Possible solution for https://github.com/lord/slate/issues/793

### DIFF
--- a/lib/nesting_unique_head.rb
+++ b/lib/nesting_unique_head.rb
@@ -1,7 +1,7 @@
-# Unique header generation
+# Nested unique header generation
 require 'middleman-core/renderers/redcarpet'
 
-$head_count = {}
+$headers_history = {}
 
 class NestingUniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
   def initialize
@@ -10,17 +10,12 @@ class NestingUniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
 
   def header(text, header_level)
     friendly_text = text.parameterize
-    $head_count[friendly_text] = header_level
-
-    last_saw_level = header_level
+    $headers_history[header_level] = text.parameterize
 
     if header_level > 1
-      $head_count.reverse_each { |text, current_level|
-        if last_saw_level >= 1
-          friendly_text.prepend("#{text}-") if current_level < header_level && current_level < last_saw_level
-          last_saw_level = current_level if current_level < last_saw_level
-        end
-      }
+      for i in (header_level - 1).downto(1)
+        friendly_text.prepend("#{$headers_history[i]}-") if $headers_history.key?(i)
+      end
     end
 
     return "<h#{header_level} id='#{friendly_text}'>#{text}</h#{header_level}>"

--- a/lib/nesting_unique_head.rb
+++ b/lib/nesting_unique_head.rb
@@ -1,0 +1,28 @@
+# Unique header generation
+require 'middleman-core/renderers/redcarpet'
+
+$head_count = {}
+
+class NestingUniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
+  def initialize
+    super
+  end
+
+  def header(text, header_level)
+    friendly_text = text.parameterize
+    $head_count[friendly_text] = header_level
+
+    last_saw_level = header_level
+
+    if header_level > 1
+      $head_count.reverse_each { |text, current_level|
+        if last_saw_level >= 1
+          friendly_text.prepend("#{text}-") if current_level < header_level && current_level < last_saw_level
+          last_saw_level = current_level if current_level < last_saw_level
+        end
+      }
+    end
+
+    return "<h#{header_level} id='#{friendly_text}'>#{text}</h#{header_level}>"
+  end
+end

--- a/lib/nesting_unique_head.rb
+++ b/lib/nesting_unique_head.rb
@@ -1,20 +1,19 @@
 # Nested unique header generation
 require 'middleman-core/renderers/redcarpet'
 
-$headers_history = {}
-
 class NestingUniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
   def initialize
     super
+    @@headers_history = {} if !defined?(@@headers_history)
   end
 
   def header(text, header_level)
     friendly_text = text.parameterize
-    $headers_history[header_level] = text.parameterize
+    @@headers_history[header_level] = text.parameterize
 
     if header_level > 1
       for i in (header_level - 1).downto(1)
-        friendly_text.prepend("#{$headers_history[i]}-") if $headers_history.key?(i)
+        friendly_text.prepend("#{@@headers_history[i]}-") if @@headers_history.key?(i)
       end
     end
 

--- a/lib/unique_head.rb
+++ b/lib/unique_head.rb
@@ -1,28 +1,17 @@
 # Unique header generation
 require 'middleman-core/renderers/redcarpet'
-
-$head_count = {}
-
 class UniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
   def initialize
     super
+    @head_count = {}
   end
-
   def header(text, header_level)
     friendly_text = text.parameterize
-    $head_count[friendly_text] = header_level
-
-    last_saw_level = header_level
-
-    if header_level > 1
-      $head_count.reverse_each { |text, current_level|
-        if last_saw_level >= 1
-          friendly_text.prepend("#{text}-") if current_level < header_level && current_level < last_saw_level
-          last_saw_level = current_level if current_level < last_saw_level
-        end
-      }
+    @head_count[friendly_text] ||= 0
+    @head_count[friendly_text] += 1
+    if @head_count[friendly_text] > 1
+      friendly_text += "-#{@head_count[friendly_text]}"
     end
-
     return "<h#{header_level} id='#{friendly_text}'>#{text}</h#{header_level}>"
   end
 end

--- a/lib/unique_head.rb
+++ b/lib/unique_head.rb
@@ -1,17 +1,28 @@
 # Unique header generation
 require 'middleman-core/renderers/redcarpet'
+
+$head_count = {}
+
 class UniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
   def initialize
     super
-    @head_count = {}
   end
+
   def header(text, header_level)
     friendly_text = text.parameterize
-    @head_count[friendly_text] ||= 0
-    @head_count[friendly_text] += 1
-    if @head_count[friendly_text] > 1
-      friendly_text += "-#{@head_count[friendly_text]}"
+    $head_count[friendly_text] = header_level
+
+    last_saw_level = header_level
+
+    if header_level > 1
+      $head_count.reverse_each { |text, current_level|
+        if last_saw_level >= 1
+          friendly_text.prepend("#{text}-") if current_level < header_level && current_level < last_saw_level
+          last_saw_level = current_level if current_level < last_saw_level
+        end
+      }
     end
+
     return "<h#{header_level} id='#{friendly_text}'>#{text}</h#{header_level}>"
   end
 end


### PR DESCRIPTION
Change mechanism how Slate generate anchor for h1-hX headers.
Current approach use all higher headers for generate anchor, for example

```
# First
## Second
### Third
# One
## Second
### Three
```

Will produce anchors

```
#first
#first-second
#third-first-second
#one
#one-second
#three-one-two
```

As a result if you have duplicate header names you always will have unique anchor on it.