### PR TITLE
Fix data-title attribute for H2 elements in TOC

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -77,7 +77,7 @@ under the License.
               <ul class="toc-list-h2">
                 <% h1[:children].each do |h2| %>
                   <li>
-                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h1[:content] %>"><%= h2[:content] %></a>
+                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content] %>"><%= h2[:content] %></a>
                   </li>
                 <% end %>
               </ul>


### PR DESCRIPTION
I believe the data-title attribute for H2 elements was mistakenly using the parent H1 content as its value, rather than its own content.

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->