### PR TITLE
Allow setting full margin from _variables.scss

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -102,7 +102,7 @@ html, body {
   }
 
   .logo {
-    margin-bottom: $logo-margin;
+    margin: $logo-margin;
   }
 
   .search-results {


### PR DESCRIPTION
Currently, setting `$logo-margin` will only adjust the logo's bottom margin, but in each project I've used slate I found I needed to adjust the left and right margin on the logo. This modification means you can now do `$logo-margin: 0px 2px 3px 2px 0px;` instead of touching `screen.css.scss` directly to add each margin direction.
I do realize, however, this could be a *breaking change* for projects where `$logo-margin` is set to, say `3px` expecting to have a 3 pixel bottom margin added but with this update would make that become a top margin.
Any suggestions on a better way to handle this are more than welcome.