### PR TITLE
fixed Markdown code formatting in _errors.md

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,6 +1,8 @@
 # Errors
 
-<aside class="notice">This error section is stored in a separate file in `includes/_errors.md`. Slate allows you to optionally separate out your docs into many files...just save them to the `includes` folder and add them to the top of your `index.md`'s frontmatter. Files are included in the order listed.</aside>
+<aside class="notice">
+This error section is stored in a separate file in <code>includes/_errors.md</code>. Slate allows you to optionally separate out your docs into many files...just save them to the <code>includes</code> folder and add them to the top of your <code>index.md</code>'s frontmatter. Files are included in the order listed.
+</aside>
 
 The Kittn API uses the following error codes:
 


### PR DESCRIPTION
In `_errors.md`, some backticks are used within the `<aside></aside>` HTML block, presumably to highlight the respective files in a code block. The backticks should be replaced with `<code></code>` instead

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->