### PR TITLE
tools: .editorconfig md trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,4 @@ trim_trailing_whitespace = true
 charset = utf-8
 
 [*.md]
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = true
 
 [*.rb]
 charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = true


### PR DESCRIPTION
Hi!

This disable trimming of whitespace on markdown files in `.editorconfig`, since they are used to insert a line break

http://markdown-guide.readthedocs.io/en/latest/basics.html#line-return