### PR TITLE
Fixes #909, reverts "don't pushState", using replaceState instead

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -76,6 +76,9 @@
         $best.siblings(tocListSelector).addClass("active");
         $toc.find(tocListSelector).filter(":not(.active)").slideUp(150);
         $toc.find(tocListSelector).filter(".active").slideDown(150);
+        if (window.history.replaceState) {
+          window.history.replaceState(null, "", best);
+        }
         // TODO remove classnames
         document.title = $best.data("title") + " – " + originalTitle;
       }


### PR DESCRIPTION
Partially reverts 95f924fd0d82c2a43db64edd22f41d7ba870261c.

Tested & verified on default kitten example.