### PR TITLE
Remove Fidor Bank from "Companies using Slate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Companies Using Slate
 * [Clearbit](https://clearbit.com/docs)
 * [Coinbase](https://developers.coinbase.com/api)
 * [Parrot Drones](http://developer.parrot.com/docs/bebop/)
-* [Fidor Bank](http://docs.fidor.de/)
 * [Scale](https://docs.scaleapi.com/)
 
 You can view more in [the list on the wiki](https://github.com/lord/slate/wiki/Slate-in-the-Wild).


### PR DESCRIPTION
Remove outdated Fidor Bank example (no longer using Slate) (Fixes #957)