### PR TITLE
Remove IBM from "Companies Using Slate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Companies Using Slate
 ---------------------------------
 
 * [NASA](https://api.nasa.gov)
-* [IBM](https://docs.cloudant.com/api.html)
 * [Sony](http://developers.cimediacloud.com)
 * [Best Buy](https://bestbuyapis.github.io/api-documentation/)
 * [Travis-CI](https://docs.travis-ci.com/api/)


### PR DESCRIPTION
IBM is not using slate anymore, at least for cloudant documentation
Current doc link: https://console.bluemix.net/docs/services/Cloudant/getting-started.html