### PR TITLE
Add support for viewing resources on multiple pages (backwards compatible)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>=2.3.1'
+ruby '2.5.1'
 source 'https://rubygems.org'
 
 # Middleman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ DEPENDENCIES
   rouge (~> 2.0.5)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.14.5
+   1.16.1

--- a/source/kittens/index.html.md
+++ b/source/kittens/index.html.md
@@ -34,54 +34,6 @@ puppers:
 
 ---
 
-# Introduction
-
-Welcome to the Kittn API! You can use our API to access Kittn API endpoints, which can get information on various cats, kittens, and breeds in our database.
-
-We have language bindings in Shell, Ruby, and Python! You can view code examples in the dark area to the right, and you can switch the programming language of the examples with the tabs in the top right.
-
-This example API documentation page was created with [Slate](https://github.com/lord/slate). Feel free to edit it and use it as a base for your own API's documentation.
-
-# Authentication
-
-> To authorize, use this code:
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-```
-
-```shell
-# With shell, you can just pass the correct header with each request
-curl "api_endpoint_here"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-```
-
-> Make sure to replace `meowmeowmeow` with your API key.
-
-Kittn uses API keys to allow access to the API. You can register a new Kittn API key at our [developer portal](http://example.com/developers).
-
-Kittn expects for the API key to be included in all API requests to the server in a header that looks like the following:
-
-`Authorization: meowmeowmeow`
-
-<aside class="notice">
-You must replace <code>meowmeowmeow</code> with your personal API key.
-</aside>
-
 # Kittens
 
 ## Get All Kittens
@@ -253,4 +205,3 @@ This endpoint deletes a specific kitten.
 Parameter | Description
 --------- | -----------
 ID | The ID of the kitten to delete
-

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -76,12 +76,13 @@ under the License.
               <li>
                 <% resource_name = resource[/^[a-zA-Z\-_\s]+:/] %>
                 <% resource_name = resource_name.to_s[0..-2] %>
+                <% resource_name_lower = resource_name.downcase %>
                 <% current_page.data.debug ? ( puts resource_name ) : '' %>
                 <% resource_url = resource[/\/?[a-zA-Z\-\.\/_]+\/index.html/] %>
                 <% current_page.data.debug ? ( puts '- ' + resource_url.to_s ) : '' %>
                 <%= link_to resource_name, resource_url, :class => 'toc-h1 toc-link', :directory_indexes => true %>
                 <ul class="toc-list-h2 active">
-                  <% current_page.data[resource_name].each do |request| %>
+                  <% current_page.data[resource_name_lower].each do |request| %>
                     <li>
                       <% request_fragment = request[/:'[a-zA-Z\-_]+'/] %>
                       <% request_fragment = request_fragment.to_s[2..-2] %>
@@ -89,7 +90,8 @@ under the License.
                       <% request_name = request[/^[a-zA-Z\-_\s]+:/] %>
                       <% request_name = request_name.to_s[0..-2] %>
                       <% current_page.data.debug ? ( puts '  ' + request_name ) : '' %>
-                      <%= link_to @request_name, resource_url + '#' + request_fragment, :class => 'toc-h2 toc-link active', :fragment => @request_fragment %>
+                      <% resource_url_full = resource_url.to_s + '#' + request_fragment.to_s %>
+                      <%= link_to @request_name, resource_url_full, :class => 'toc-h2 toc-link active', :fragment => @request_fragment %>
                       <%= request %>
                     </li>
                   <% end %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -54,8 +54,8 @@ under the License.
       <%= image_tag "logo.png", class: 'logo' %>
       <% if language_tabs.any? %>
         <div class="lang-selector">
-          <% language_tabs.each do |lang| %>
-            <% if lang.is_a? Hash %>
+          <% language_tabs.each do |lang| 
+            if lang.is_a? Hash %>
               <a href="#" data-language-name="<%= lang.keys.first %>"><%= lang.values.first %></a>
             <% else %>
               <a href="#" data-language-name="<%= lang %>"><%= lang %></a>
@@ -69,20 +69,49 @@ under the License.
         </div>
         <ul class="search-results"></ul>
       <% end %>
-      <ul id="toc" class="toc-list-h1">
-        <% toc_data(page_content).each do |h1| %>
-          <li>
-            <a href="#<%= h1[:id] %>" class="toc-h1 toc-link" data-title="<%= h1[:content].to_s.parameterize %>"><%= h1[:content] %></a>
-            <% if h1[:children].length > 0 %>
-              <ul class="toc-list-h2">
-                <% h1[:children].each do |h2| %>
-                  <li>
-                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content].to_s.parameterize %>"><%= h2[:content] %></a>
-                  </li>
-                <% end %>
-              </ul>
+      <div id="toc" class="toc-list-h1">
+        <% if current_page.data.multiple_pages %>
+          <div id="toc">
+            <% current_page.data.resources.each do |resource| %>
+              <li>
+                <% resource_name = resource[/^[a-zA-Z\-_\s]+:/] %>
+                <% resource_name = resource_name.to_s[0..-2] %>
+                <% current_page.data.debug ? ( puts resource_name ) : '' %>
+                <% resource_url = resource[/\/?[a-zA-Z\-\.\/_]+\/index.html/] %>
+                <% current_page.data.debug ? ( puts '- ' + resource_url.to_s ) : '' %>
+                <%= link_to resource_name, resource_url, :class => 'toc-h1 toc-link', :directory_indexes => true %>
+                <ul class="toc-list-h2 active">
+                  <% current_page.data[resource_name].each do |request| %>
+                    <li>
+                      <% request_fragment = request[/:'[a-zA-Z\-_]+'/] %>
+                      <% request_fragment = request_fragment.to_s[2..-2] %>
+                      <% current_page.data.debug ? ( puts '  ' + request_fragment ) : '' %>
+                      <% request_name = request[/^[a-zA-Z\-_\s]+:/] %>
+                      <% request_name = request_name.to_s[0..-2] %>
+                      <% current_page.data.debug ? ( puts '  ' + request_name ) : '' %>
+                      <%= link_to @request_name, resource_url + '#' + request_fragment, :class => 'toc-h2 toc-link active', :fragment => @request_fragment %>
+                      <%= request %>
+                    </li>
+                  <% end %>
+                </ul>
+              </li>
             <% end %>
-          </li>
+          </div>
+        <% else %>
+          <% toc_data(page_content).each do |h1| %>
+            <li>
+              <a href="#<%= h1[:id] %>" class="toc-h1 toc-link" data-title="<%= h1[:content].to_s.parameterize %>"><%= h1[:content] %></a>
+              <% if h1[:children].length > 0 %>
+                <ul class="toc-list-h2">
+                  <% h1[:children].each do |h2| %>
+                    <li>
+                      <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content].to_s.parameterize %>"><%= h2[:content] %></a>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </li>
+          <% end %>
         <% end %>
       </ul>
       <% if current_page.data.toc_footers %>

--- a/source/puppers/index.html.md
+++ b/source/puppers/index.html.md
@@ -1,0 +1,207 @@
+---
+title: API Reference
+
+language_tabs: # must be one of https://git.io/vQNgJ
+  - shell
+  - ruby
+  - python
+  - javascript
+
+toc_footers:
+  - <a href='#'>Sign Up for a Developer Key</a>
+  - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
+
+includes:
+  - errors
+
+search: true
+
+multiple_pages: true
+
+resources:
+  - kittens:'/kittens/index.html'
+  - puppers:'/puppers/index.html'
+
+kittens:
+  - Get All Kittens:'get-all-kittens'
+  - Get a specific kitten:'get-a-specific-kitten'
+  - Delete a specific kitten:'delete-a-specific-kitten'
+
+puppers:
+  - Get All Puppers:'get-all-puppers'
+  - Get a specific pupper:'get-a-specific-pupper'
+  - Delete a specific pupper:'delete-a-specific-pupper'
+
+---
+
+# Kittens
+
+## Get All Puppers
+
+```ruby
+require 'puppr'
+
+api = Puppr::APIClient.authorize!('woofwoofwoof')
+api.puppers.get
+```
+
+```python
+import puppr
+
+api = puppr.authorize('woofwoofwoof')
+api.puppers.get()
+```
+
+```shell
+curl "http://example.com/api/puppers"
+  -H "Authorization: woofwoofwoof"
+```
+
+```javascript
+const puppr = require('puppr');
+
+let api = puppr.authorize('woofwoofwoof');
+let puppers = api.puppers.get();
+```
+
+> The above command returns JSON structured like this:
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Fluffums",
+    "breed": "calico",
+    "fluffiness": 6,
+    "cuteness": 7
+  },
+  {
+    "id": 2,
+    "name": "Max",
+    "breed": "unknown",
+    "fluffiness": 5,
+    "cuteness": 10
+  }
+]
+```
+
+This endpoint retrieves all puppers.
+
+### HTTP Request
+
+`GET http://example.com/api/puppers`
+
+### Query Parameters
+
+Parameter | Default | Description
+--------- | ------- | -----------
+include_doggos | false | If set to true, the result will also include big ol' puppers.
+available | true | If set to false, the result will include puppers that have already been adopted.
+
+<aside class="success">
+Remember — a happy pupper is an authenticated pupper!
+</aside>
+
+## Get a Specific Pupper
+
+```ruby
+require 'puppr'
+
+api = Puppr::APIClient.authorize!('woofwoofwoof')
+api.kittens.get(2)
+```
+
+```python
+import puppr
+
+api = puppr.authorize('woofwoofwoof')
+api.puppers.get(2)
+```
+
+```shell
+curl "http://example.com/api/puppers/2"
+  -H "Authorization: woofwoofwoof"
+```
+
+```javascript
+const puppr = require('puppr');
+
+let api = puppr.authorize('woofwoofwoof');
+let max = api.puppers.get(2);
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": 2,
+  "name": "Max",
+  "breed": "unknown",
+  "fluffiness": 5,
+  "cuteness": 10
+}
+```
+
+This endpoint retrieves a specific pupper.
+
+<aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside>
+
+### HTTP Request
+
+`GET http://example.com/puppers/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the pupper to retrieve
+
+## Delete a Specific Pupper
+
+```ruby
+require 'puppr'
+
+api = Puppr::APIClient.authorize!('woofwoofwoof')
+api.puppers.delete(2)
+```
+
+```python
+import puppr
+
+api = puppr.authorize('woofwoofwoof')
+api.puppers.delete(2)
+```
+
+```shell
+curl "http://example.com/api/puppers/2"
+  -X DELETE
+  -H "Authorization: woofwoofwoof"
+```
+
+```javascript
+const puppr = require('puppr');
+
+let api = puppr.authorize('woofwoofwoof');
+let max = api.puppers.delete(2);
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": 2,
+  "deleted" : ":("
+}
+```
+
+This endpoint deletes a specific kitten.
+
+### HTTP Request
+
+`DELETE http://example.com/puppers/<ID>`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the pupper to delete


### PR DESCRIPTION
After wanting to have better support for multiple pages, I rewrote parts of the layout.erb and added a second example resource to better show the changes. There are a few known issues that I plan to work on, but for individuals that want the basis of having multiple pages, this works well enough. I elected not to edit the javascript this time around to preserve backwards compatibility. I have done some work on Rspec_Api_Documentation to support this branch. It can be found [here](https://github.com/E1337Kat/rspec_api_documentation). That branch is still wip, so read over the changes here and there to use RAD with slate paged. 

## Changes:
- You can list your resources on all pages, as well as the requests for that resource
- The new changes only go into affect if `multiple_pages: true` is included in the index.html.md yaml.
- This makes all these additions completely backwards compatible.
- updated the ruby and bundler (Only because bundler wasn't working when I forked it straight up)

## Known Issues:
- The toc does not include the "includes." it's weird as the search does sometimes.
- The toc drop down does not work. This is because I did _not_ edit any of the _toc.js
- Search is a bit weird. I did not edit it yet. 