### PR TITLE
Add i18n support with middleman features

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -22,6 +22,11 @@ under the License.
     end
   end
 %>
+<%
+  t_reg = /t\(([^\)]+)\)/
+  current_page.data.title = current_page.data.title.gsub(t_reg){|t| eval(t)}
+  page_content = page_content.gsub(t_reg){|t| eval(t)}
+%>
 
 <!doctype html>
 <html>
@@ -88,7 +93,7 @@ under the License.
       <% if current_page.data.toc_footers %>
         <ul class="toc-footer">
           <% current_page.data.toc_footers.each do |footer| %>
-            <li><%= footer %></li>
+            <li><%= footer.gsub(t_reg){|t| eval(t)} %></li>
           <% end %>
         </ul>
       <% end %>


### PR DESCRIPTION
Hi, I would like to host our API docs as multilingual pages using middleman i18n features so made a small change to the source. Hope this change will contribute to others who have the similar needs so opening this pull request to base fork.

The following is how to i18n your slate sites.

1.  Follow the middleman i18n steps, create the directory "localizable" under the "source" and move "index.html.md" there and create the directory "locales" under the root and put your target message files (e.g. "en.yml", "ja.yml"...)  The details is:  https://middlemanapp.com/advanced/localization/
(This is not included by my PR, done by users)

2.  Embed "t(:YOUR_MESSAGE_KEY)" in index and other included .md files to where you want to i18n.
  e.g.
  index.html.md
      title: t(:title)
  --
  en.yml
    en:
    title: "My Title"
  --
  ja.yml
    ja:
      title: "私のタイトル"

3.  now you can see "My title" in "YOUR_URL/en" and "私のタイトル" in "YOUR_URL/ja". How you can manage the path for localization is fully controlled by middle man i18n above.

4. This localization is applied to HTML title and page content and footers. 