### PR TITLE
Allow main-h1-bg, logo-margin-top configuration

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -35,6 +35,7 @@ $lang-select-bg: #1E2224 !default;
 $lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #F3F7F9 !default;
+$main-h1-bg: #FDFDFD !default;
 $aside-notice-bg: #8fbcd4 !default;
 $aside-warning-bg: #c97a7e !default;
 $aside-success-bg: #6ac174 !default;

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -57,7 +57,8 @@ $lang-select-pressed-text: #fff !default; // color of language tab text when mou
 ////////////////////
 $nav-width: 230px !default; // width of the navbar
 $examples-width: 50% !default; // portion of the screen taken up by code examples
-$logo-margin: 0px !default; // margin below logo
+$logo-margin-top: 0px !default; // margin above logo
+$logo-margin-bot: 0px !default; // margin below logo
 $main-padding: 28px !default; // padding to left and right of content & examples
 $nav-padding: 15px !default; // padding to left and right of navbar
 $nav-v-padding: 10px !default; // padding used vertically around search boxes and results

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -353,7 +353,7 @@ html, body {
     margin-top: 2em;
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
-    background-color: #fdfdfd;
+    background-color: $main-h1-bg;
   }
 
   h1:first-child, div:first-child + h1 {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -75,7 +75,8 @@ html, body {
   .logo {
     display: block;
     max-width: 100%;
-    margin-bottom: $logo-margin;
+    margin-top: $logo-margin-top;  
+    margin-bottom: $logo-margin-bot;
   }
 
   &>.search {


### PR DESCRIPTION
This PR adds a new item to `_variables.scss` to allow configuration of `main-h1-bg`, for example:

```scss
// ...
$main-bg: #F3F7F9 !default;
$main-h1-bg: #c97a7e !default; // this is some kind of red
$aside-notice-bg: #8fbcd4 !default;
// ...
```

now you get:

![image](https://user-images.githubusercontent.com/23356519/52454261-fe1f4500-2aff-11e9-9d0c-3f95a500f863.png)

and for logo margins, if you change it slightly:

```scss
$logo-margin-top: 16px !default; // margin above logo
$logo-margin-bot: 0px !default; // margin below logo
```

you now have a much nicer spacing on the navbar:

![image](https://user-images.githubusercontent.com/23356519/52455590-9b30ac80-2b05-11e9-9ad7-f1c7c8b4a885.png)
