### PR TITLE
updated config.rb to activate asset_hash

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -40,6 +40,7 @@ set :relative_links, true
 
 # Build Configuration
 configure :build do
+  activate :asset_hash
   # If you're having trouble with Middleman hanging, commenting
   # out the following two lines has been known to help
   activate :minify_css


### PR DESCRIPTION
We host our api docs on s3 and cache with `max-age=one-year-in-seconds`. In order to do this we had to add `activate: asset_hash` to the config. It works as is.

Any reason this shouldn't be a default config?

![Screen Shot 2019-03-15 at 9 08 20 AM](https://user-images.githubusercontent.com/32788783/54401254-e7bd6800-4701-11e9-96dd-26bffaa69795.png)
