### PR TITLE
Add additional level to ToC based on h3 tags

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -78,6 +78,15 @@ under the License.
                 <% h1[:children].each do |h2| %>
                   <li>
                     <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:title] %>"><%= h2[:content] %></a>
+                      <% if h2[:children].length > 0 %>
+                        <ul class="toc-list-h3">
+                          <% h2[:children].each do |h3| %>
+                            <li>
+                              <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h3[:title] %>"><%= h3[:content] %></a>
+                            </li>
+                          <% end %>
+                        </ul>
+                      <% end %>
                   </li>
                 <% end %>
               </ul>

--- a/source/stylesheets/_rtl.scss
+++ b/source/stylesheets/_rtl.scss
@@ -19,7 +19,11 @@ $default: auto;
 }
 
 .toc-h2 {
-    padding-#{right}: $nav-padding + $nav-indent;
+    padding-#{right}: $nav-padding + $nav-first-level-indent;
+}
+
+.toc-h3 {
+    padding-#{right}: $nav-padding + $nav-second-level-indent;
 }
 
 #nav-button {

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -60,7 +60,8 @@ $logo-margin: 0px !default; // margin below logo
 $main-padding: 28px !default; // padding to left and right of content & examples
 $nav-padding: 15px !default; // padding to left and right of navbar
 $nav-v-padding: 10px !default; // padding used vertically around search boxes and results
-$nav-indent: 10px !default; // extra padding for ToC subitems
+$nav-first-level-indent: 10px !default; // extra padding for first level ToC subitems
+$nav-second-level-indent: 20px !default; // extra padding for second level ToC subitems
 $code-annotation-padding: 13px !default; // padding inside code annotations
 $h1-margin-bottom: 21px !default; // padding under the largest header tags
 $tablet-width: 930px !default; // min width before reverting to tablet size

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -170,8 +170,13 @@ html, body {
   }
 
   .toc-h2 {
-    padding-left: $nav-padding + $nav-indent;
+    padding-left: $nav-padding + $nav-first-level-indent;
     font-size: 12px;
+  }
+
+  .toc-h3 {
+    padding-left: $nav-padding + $nav-second-level-indent;
+    font-size: 11px;
   }
 
   .toc-footer {
@@ -386,7 +391,11 @@ html, body {
     margin-bottom: 0.8em;
   }
 
-  h4, h5, h6 {
+  h4 {
+    font-size: 11px;
+  }
+
+  h5, h6 {
     font-size: 10px;
   }
 


### PR DESCRIPTION
`h3` tags are now being parsed in order to add an additional level of subitems to table of contents. 
It can be helpful when you want to add differentiation of the first level items of ToC. For example, when you have API v1 and API v2 descriptions.

Before
![image](https://user-images.githubusercontent.com/9015684/56650626-1d098e00-6690-11e9-9347-8d022d382e22.png)

After
![image](https://user-images.githubusercontent.com/9015684/56659609-41706500-66a6-11e9-8e1d-d1cf852ce4be.png)


Feel free to discuss this feature and suggest alternative ways!


